### PR TITLE
News - OpenELA Announces kernel-lts Project in Support of Linux Kernel 4.14

### DIFF
--- a/content/announcements.md
+++ b/content/announcements.md
@@ -4,6 +4,7 @@ include_footer: true
 sidebar: false
 ---
 
+* [OpenELA Announces kernel-lts Project in Support of Linux Kernel 4.14](/news/2024.03.12-support-linux-kernel-4.14) _(March 12th, 2024)_
 * [OpenELA Initiates a Documentation Repository for the Community](/news/2023.12.13-initiate-documentation-repository/) _(December 13th, 2023)_
 * [OpenELA Marks Major Milestones in Governance and Code Availability](/news/2023.11.02-governance_and_code_availability/) _(November 2nd, 2023)_
 * [OpenELA Current Status and What's Coming Next](/news/2023.09.07-current_status) _(September 6th, 2023)_

--- a/content/news/2024.03.12-support-linux-kernel-4.14.md
+++ b/content/news/2024.03.12-support-linux-kernel-4.14.md
@@ -1,0 +1,47 @@
+---
+title: OpenELA Announces kernel-lts Project in Support of Linux Kernel 4.14
+Author: OpenELA Community
+Date: March 12th, 2024
+---
+__Author:__ OpenELA Community \
+__Date:__ March 12th, 2024
+
+***As support from the larger open source community concludes, enterprise vendors team up to collaborate on long-term kernel maintenance***
+
+**RENO, Nev., AUSTIN, Texas, and LUXEMBOURG—March 12, 2024—** OpenELA is committing to providing a platform for developers to collaborate on the maintenance of the 4.14 Linux kernel after community support ended in January.
+
+The [OpenELA kernel-lts project](https://github.com/openela/kernel-lts) is a repository that contains a continuation of long-term maintenance kernel releases hosted on [kernel.org](https://www.kernel.org/category/releases.html). This continuation follows all the upstream [stable rules](https://www.kernel.org/doc/html/latest/process/stable-kernel-rules.html), does not target specific hardware, vendors, or users, and the patches are primarily selected from ongoing upstream stable kernels.
+
+OpenELA is a trade association of open source enterprise Linux distribution developers originally founded by CIQ, Oracle and SUSE. OpenELA’s mission is to provide a secure, transparent and reliable enterprise Linux source that is globally available to all as a buildable base. 
+
+“The OpenELA kernel-lts project is the first forum for enterprise Linux distribution vendors to pool our resources and collaborate on those older kernels after upstream support for those kernels has ended,” said Greg Marsden, SVP, Oracle Linux, Oracle. “The enterprise Linux distribution vendors that are contributing to the kernel-lts project have more recent enterprise kernels that we recommend for most workloads.”
+
+“As enterprise distribution vendors, we are often tasked to keep software viable even after community support has ended,” said Gregory M. Kurtzer, CEO, CIQ. “We believe that open collaboration is the best way to maintain foundational enterprise infrastructure. Through OpenELA, vendors, users and the open source community at large can work together to provide the longevity that professional IT organizations require for enterprise Linux.” 
+
+### About OpenELA
+OpenELA exists to deliver open source code, tools and systems for the community. Core tenets include full compliance with this existing standard, swift updates and secure fixes, transparency, community and ensuring that these resources remain free and redistributable for all. OpenELA welcomes all organizations focused on delivering reliable and secure access to Enterprise Linux packages and build systems. OpenELA seeks to build robust, community-driven standards that ensure impartiality and equilibrium in the broad EL ecosystem. For more information about getting involved with OpenELA, please visit [www.OpenELA.org/join](https://www.openela.org/join/?utm_source=web&utm_medium=press-release&utm_campaign=openela&utm_id=kernel-tts-project-in-support-of-linux-kernel-4-14/).
+
+### Trademarks
+Oracle, Java, MySQL and NetSuite are registered trademarks of Oracle Corporation. NetSuite was the first cloud company—ushering in the new era of cloud computing.
+
+### Media Contacts:
+**CIQ**\
+Cristin Connelly\
+Cathey.co for CIQ\
+cristin@cathey.co
+
+**Oracle**\
+Drew Smith\
+drew.j.smith@oracle.com\
+1-415-336-1103
+
+**SUSE**\
+Sara Matheson\
+Sara.matheson@suse.com\
++44 (0) 7960 191229
+
+**OpenELA**\
+Cristin Connelly\
+Cathey.co for OpenELA\
+cristin@cathey.co 
+


### PR DESCRIPTION
This adds the announcement to the News section of the site.