### PR TITLE
[Bug] GitHub Actions: upload-pages-artifact version bump

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 

--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3.0.1
         with:
           path: ./public
 


### PR DESCRIPTION
Looks like GitHub has newer versions of `upload-pages-artifact`

Bumping to v2.
v3 and v3.0.1 are also available.