### PR TITLE
Remove urldefense.com link from elvalidated-compatibility-toolset.md

### DIFF
--- a/content/blog/elvalidated-compatibility-toolset.md
+++ b/content/blog/elvalidated-compatibility-toolset.md
@@ -25,7 +25,7 @@ By enabling organizations and developers that provide Enterprise Linux distribut
 *   Reduced business cost   
 *   More secure environments
 
-Learn more about ELValidated [here](https://urldefense.com/v3/__https:/github.com/openela/Compatibility__;!!ACWV5N9M2RV99hQ!J7M4OcM4qlcj52NDOLWsl_i8e1qopl0TwADA5C-hmvmaJ-3OcyquAgXgb_1gxlKxStZmqNPmMjYq2WIID4I$). 
+Learn more about ELValidated [here](https:/github.com/openela/Compatibility). 
 
 ## Supporting Quotes
 


### PR DESCRIPTION
Working with Gwendolyn on a new blog post and notice there were a few instances of URLs being redirected to a urldefense.com address (similar to a link shortener).

Neither of us knows where it came from, and I've asked Gwendolyn to remove them from the WIP blog post. But, I did find this one instance which I'd like cleaned up (if there's a legit reason for these, let me know, please).

urldefense.com is a Proofpoint security/phishing service/product, fwiw, but I don't see a reason **_not_** to serve readers a clean URL.