### PR TITLE
changed list.html to remove the extra blog, news, article words

### DIFF
--- a/content/blog/openela-in-2025.md
+++ b/content/blog/openela-in-2025.md
@@ -1,0 +1,74 @@
+---
+title: OpenELA in 2025-A Year That Established Stability and Set the Course Ahead
+slug: openela-in-2025 
+date: 2026-01-24T12:16:31-05:00
+author: OpenELA Board, authored by Arthur Tyde, Board Chair
+---
+
+As we begin 2026, it is worth reflecting on what OpenELA achieved over the past year and why that progress matters to the future of Enterprise Linux. For organizations building, distributing, or supporting Enterprise Linux systems, 2025 marked the point at which OpenELA moved from a promising idea to a dependable industry foundation.
+
+OpenELA was created in 2024 to serve a clear purpose: [to ensure that Enterprise Linux remains open, stable and broadly accessible](https://openela.org/blog/advancing-enterprise-linux-collaboration/). The trade association provides a community-maintained Enterprise Linux source and a shared compatibility standard that allow multiple distributions to interoperate reliably. In an IT environment where long-term stability, predictable platforms, and real choice are essential, OpenELA has become an important pillar of the ecosystem. For distribution maintainers and ISVs alike, this foundation reduces fragmentation while preserving the freedom to innovate and differentiate.
+
+In 2025, OpenELA moved decisively from early momentum to operational credibility.
+
+**From promise to execution**
+
+One of the most significant outcomes of the past year was OpenELA’s continued demonstration that it can operate at scale. Maintaining Enterprise Linux sources requires more than publishing code. It demands discipline, transparent processes, and sustained collaboration across organizations that may otherwise compete in the marketplace.
+
+This operational discipline also supports an increasingly important requirement: trust in the software supply chain. By delivering sources openly, repeatably, and under shared governance, OpenELA contributes to stronger provenance, auditability, and confidence in Enterprise Linux systems used in security-sensitive and regulated environments.
+
+Throughout 2025, OpenELA showed that this model works. The group reliably delivered the latest source updates, operated in the open, and maintained clear governance through its board, Technical Steering Committee, and working groups, while also leveraging and refining open source automation to support repeatable, transparent source delivery at scale. This consistency is essential. Enterprises, ISVs, and distribution maintainers need confidence that the foundation they rely on will be there tomorrow and five years from now.
+
+That confidence is earned through execution, and OpenELA earned it over the course of the year, as evidenced by Enterprise Linux source delivered and consumed by multiple major Linux distribution vendors, with solutions deployed across diverse environments, from on-premises bare-metal servers and virtualized systems to major public clouds.
+
+**Turning compatibility into a shared standard**
+
+A defining milestone in 2025 was [the introduction and expansion of ELValidated](https://www.computerweekly.com/blog/Open-Source-Insider/OpenELA-compatibility-toolset-helps-Linux-distros-reduce-testing-costs), OpenELA’s compatibility toolset. These open source tools give distributions, ISVs, and end users a transparent way to verify Enterprise Linux binary compatibility for themselves, replacing assumptions with measurable validation.
+
+Compatibility is often discussed as a goal, but without a shared standard it remains subjective. ELValidated changed that dynamic by providing an open, verifiable way to measure binary compatibility across Enterprise Linux distributions.
+
+For ISVs and IHVs, this reduces cost and time. Validating software across multiple platforms has historically required repeated testing cycles and parallel certification efforts. ELValidated reduces that burden by enabling a common baseline. Validate once and confidently support multiple OpenELA-compatible distributions, while giving customers greater confidence that applications will behave consistently across environments.
+
+Throughout the year, industry coverage highlighted how this approach helps reduce product delivery and support costs while increasing confidence in runtime behavior. More importantly, ELValidated moved quickly from concept to practice. Multiple distributions successfully validated against the standard in 2025, proving that a shared compatibility framework can work across vendors and implementations.
+
+This kind of adoption is a strong signal of long-term viability.
+
+**Improving lifecycle operations with Leapp**
+
+Another important area of progress in 2025 was OpenELA’s work around in-place upgrades through the Leapp open source project. Enterprise Linux environments are often expected to run for many years, and safe upgrades are a critical operational requirement.
+
+By introducing and [expanding Leapp support for OpenELA-compatible systems](https://fossforce.com/2025/04/oracle-brings-its-version-of-leapp-in-place-upgrade-tool-to-openela/), the organization addressed a real-world challenge faced by enterprise operators. Leapp enables controlled, in-place upgrades between major Enterprise Linux versions, helping organizations modernize systems while reducing downtime and risk.
+
+The growing vendor participation around Leapp during 2025 reinforced a broader point. OpenELA is not only focused on source availability and standards, but also on the practical tools that enterprises need to operate at scale.
+
+**Evidence of adoption and trust**
+
+Relevance is ultimately measured by adoption, and in 2025, OpenELA saw growing evidence that organizations trust what we’re delivering and are building on it. [NAVER’s decision to use OpenELA source code](https://openela.org/blog/naver-navix-using-openela-source/) for its Navix distribution is one such example. It reflects confidence not only in the code itself but also in the governance model and the organization’s long-term direction.
+
+At the same time, [OpenELA continued to attract attention from ISVs](https://tfir.io/why-isvs-targeting-linux-should-join-the-industry-backed-openela-alan-clark/) and ecosystem partners who recognized the value of an industry-backed Enterprise Linux standard. Engagement throughout the year reinforced a shared understanding that collaboration at this layer benefits everyone, from vendors to end users.
+
+**Governance that supports longevity**
+
+Technical success alone may be insufficient to ensure longevity. Governance does. [OpenELA’s transparent governance model](https://github.com/openela/governance) continued to mature in 2025, with open technical discussions, published decisions and active working groups focused on compatibility, tooling, and source stewardship.
+
+This shared responsibility is central to OpenELA’s mission. It ensures that no single vendor controls the definition of Enterprise Linux compatibility and that decisions are made in the interest of the broader ecosystem. That balance is essential for long-term stability and trust, and it provides a clear incentive for organizations whose businesses benefit from a well-defined, openly governed compatibility standard.
+
+**Looking forward**
+
+The progress made in 2025 positioned OpenELA for continued growth in the year ahead. The foundations are now firmly in place: a stable source, a working compatibility standard, practical tooling, and an engaged community.
+
+Looking ahead, the opportunity lies in expanding adoption, validating additional distributions, deepening ISV participation, and continuing to evolve the validation tools and compatibility standard as Enterprise Linux itself evolves. The work of the past year demonstrates that OpenELA is not a temporary response to change, but a durable investment in the future of Enterprise Linux.
+
+**What OpenELA Is not**
+
+OpenELA is not a Linux distribution, nor is it a replacement for the innovation and differentiation that distributions provide. It is not a single-vendor initiative, and it is not governed to advance the interests of any one company. OpenELA does not seek to fragment the Enterprise Linux ecosystem or redefine it unilaterally. Instead, it provides a shared, openly governed foundation, source base, and compatibility framework upon which multiple distributions and vendors can confidently build. By focusing on what must be common, OpenELA enables greater choice, stability, and innovation everywhere else.
+
+**An open invitation to join us**
+
+OpenELA succeeds through participation. Whether you are a distribution maintainer, an ISV, an enterprise operator or an individual contributor, there are many ways to engage. Use the source. Adopt ELValidated. Participate in working groups. Contribute financially. Help shape the next phase of Enterprise Linux collaboration. You choose.
+
+For organizations whose businesses depend on Enterprise Linux stability and compatibility, becoming an OpenELA member offers a direct way to influence standards, collaborate with peers and invest in the long-term health of the ecosystem. Email us: [info@openela.org](mailto:info@openela.org). 
+
+The achievements of 2025 proved that OpenELA is stable, credible, and here to stay. We invite the community to build with us as we continue this work in 2026 and beyond.
+
+\# \# \#

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -27,9 +27,6 @@
             {{ range $blogs.ByDate.Reverse }}
               <li>
                 <a href="{{ .Permalink }}">
-                  {{- if .Type -}}
-                    <span class=postType>{{.Type}}</span>
-                  {{- end -}}
                   {{ .Title }}
                 </a>
                 (<em>{{ .Date.Format "January" }} {{ .Date.Format "2" }}{{ if in (slice 1 21 31) .Date.Day}}st{{ else if in (slice 2 22) .Date.Day}}nd{{ else if in (slice 3 23) .Date.Day}}rd{{ else }}th{{ end }}, {{ .Date.Format "2006" }}</em>)
@@ -50,9 +47,6 @@
                 {{- else -}}
                 <a href="{{ .Permalink }}">
                 {{- end -}}
-                  {{- if .Type -}}
-                    <span class=postType>{{.Type}}</span>
-                  {{- end -}}
                   {{ .Title }}
                 </a>
                 (<em>{{ .Date.Format "January" }} {{ .Date.Format "2" }}{{ if in (slice 1 21 31) .Date.Day}}st{{ else if in (slice 2 22) .Date.Day}}nd{{ else if in (slice 3 23) .Date.Day}}rd{{ else }}th{{ end }}, {{ .Date.Format "2006" }}</em>)


### PR DESCRIPTION
The Communications committee desires that the extra words - blog, news, article.  This pull request is to delete 6 lines of code in the list.html file.  Those lines of code were adding the extra words to the web page. 

I ran the code change using hugo v0.152.1+extended linux/amd64 BuildDate=unknown
I think this might be a much newer version than what is being used on the website.